### PR TITLE
Renamed environment name in environment.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Anaconda, run:
 to install all the dependencies into an isolated environment. You can switch to
 this environment by running:
 
-    source activate pymc
+    source activate stat-rethink-pymc3
 
 
 ---

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: pymc
+name: stat-rethink-pymc3
 channels:
 - defaults
 dependencies:


### PR DESCRIPTION
Changed environment name to `stat-rethink-pymc3` in `README.md` and
`environment.yml`

Fixes #55